### PR TITLE
Ensure lightningcss is available during builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,7 @@ Grid: Heating up.
 ---
 
 **Join us, or get left clean.**  
+
+### Development
+
+Install dependencies with `npm install`. The build relies on the `lightningcss` package, which must be included in production dependencies to compile styles correctly.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "splat-landing",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "build": "next build",
+    "test": "echo 'no tests'"
+  },
+  "dependencies": {
+    "lightningcss": "^1.24.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add package.json with lightningcss listed in dependencies
- document the need for lightningcss in build instructions

## Testing
- `npm test`
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/lightningcss)*

------
https://chatgpt.com/codex/tasks/task_b_689809e9107c832fb26d593152668443